### PR TITLE
Improve support for older browsers/devices

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,9 +1,9 @@
 >= 0.5%
 last 2 major versions
 not dead
-Chrome >= 60
-Firefox >= 60
+Chrome >= 90
+Firefox >= 91
 Firefox ESR
-iOS >= 12
-Safari >= 12
+iOS >= 15
+Safari >= 15
 not Explorer <= 11

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
 import path from 'path'
+import legacy from '@vitejs/plugin-legacy'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,6 +12,11 @@ export default defineConfig({
     VueI18nPlugin({
       include: [path.resolve(__dirname, './src/locales/**')],
       strictMessage: false
+    }),
+    // support older browsers
+    legacy({
+      modernTargets: 'iOS >= 15, Safari >= 15',
+      modernPolyfills: true
     })
   ],
   resolve: {


### PR DESCRIPTION
Apply @vitejs/plugin-legacy to use polyfills with older and modern browsers