### PR TITLE
Add stats.postGameStats

### DIFF
--- a/src/util/stats/postGameStats.ts
+++ b/src/util/stats/postGameStats.ts
@@ -1,0 +1,50 @@
+/**
+ * Posts game stats anonymously to a Google Form.
+ * This is done asynchronously to avoid blocking the UI.
+ * @param data Game stats data
+ * @param formsURL URL for the Google Form to post data to. If not set, not data is posted.
+ * @param fieldMapping Field mapping string to map data properties to form entry IDs with syntax `fieldName:entryID;fieldName2:entryID2`.
+ */
+export default function(data: object, formsURL?:string, fieldMapping?: string) : void {
+  if (!formsURL) {
+    // skip silently if no URL is configured
+    return
+  }
+
+  const mapping = parseFieldMapping(fieldMapping)
+  const formData = new FormData()
+
+  // Map data properties to form field names
+  Object.entries(data).forEach(([key, value]) => {
+    const fieldName = mapping.get(key)
+    if (fieldName && value !== undefined && value !== null) {
+      formData.append(fieldName, String(value))
+    }
+  })
+
+  // Post data asynchronously
+  fetch(formsURL, {
+    method: 'POST',
+    body: formData,
+    mode: 'no-cors' // Google Forms requires no-cors mode
+  })
+  .then(() => {
+    console.debug('Game stats posted successfully')
+  })
+  .catch((error) => {
+    console.error(`Failed to post game stats to ${formsURL}: `, error)
+  })
+}
+
+function parseFieldMapping(fieldMapping?: string) : Map<string, string> {
+  const map = new Map<string, string>()
+  if (fieldMapping) {
+    fieldMapping.split(';').forEach((pair: string) => {
+      const [key, value] = pair.split(':')
+      if (key && value) {
+        map.set(key, value)
+      }
+    })
+  }
+  return map
+}

--- a/src/util/stats/postGameStats.ts
+++ b/src/util/stats/postGameStats.ts
@@ -28,9 +28,6 @@ export default function(data: object, formsURL?:string, fieldMapping?: string) :
     body: formData,
     mode: 'no-cors' // Google Forms requires no-cors mode
   })
-  .then(() => {
-    console.debug('Game stats posted successfully')
-  })
   .catch((error) => {
     console.error(`Failed to post game stats to ${formsURL}: `, error)
   })

--- a/tests/unit/util/stats/postGameStats.spec.ts
+++ b/tests/unit/util/stats/postGameStats.spec.ts
@@ -1,0 +1,252 @@
+import postGameStats from '@/util/stats/postGameStats'
+import { expect, vi } from 'vitest'
+
+describe('util/stats/postGameStats', () => {
+  beforeEach(() => {
+    // Mock fetch globally
+    global.fetch = vi.fn()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should skip posting when no formsURL is provided', () => {
+    const data = { score: 100, turns: 10 }
+    
+    postGameStats(data)
+    
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('should skip posting when formsURL is empty string', () => {
+    const data = { score: 100, turns: 10 }
+    
+    postGameStats(data, '')
+    
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('should post data with correct form data when formsURL is provided', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200
+    })
+    global.fetch = mockFetch
+
+    const data = { score: 100, turns: 10, money: 250 }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const fieldMapping = 'score:entry.123;turns:entry.456;money:entry.789'
+    
+    postGameStats(data, formsURL, fieldMapping)
+    
+    // Wait for async operation
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(mockFetch).toHaveBeenCalledWith(
+      formsURL,
+      expect.objectContaining({
+        method: 'POST',
+        mode: 'no-cors'
+      })
+    )
+    
+    // Check that FormData was created with correct mappings
+    const callArgs = mockFetch.mock.calls[0]
+    const formData = callArgs[1].body
+    expect(formData).toBeInstanceOf(FormData)
+  })
+
+  it('should map data properties to form fields correctly', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+
+    const data = { score: 150, turns: 8, difficulty: 'hard' }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const fieldMapping = 'score:entry.111;turns:entry.222;difficulty:entry.333'
+    
+    postGameStats(data, formsURL, fieldMapping)
+    
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    const callArgs = mockFetch.mock.calls[0]
+    const formData = callArgs[1].body as FormData
+    
+    // Verify form data contains mapped values
+    expect(formData.get('entry.111')).toBe('150')
+    expect(formData.get('entry.222')).toBe('8')
+    expect(formData.get('entry.333')).toBe('hard')
+  })
+
+  it('should skip undefined and null values in data', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+
+    const data = { 
+      score: 100, 
+      turns: undefined, 
+      money: null, 
+      difficulty: 'easy' 
+    }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const fieldMapping = 'score:entry.111;turns:entry.222;money:entry.333;difficulty:entry.444'
+    
+    postGameStats(data, formsURL, fieldMapping)
+    
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    const callArgs = mockFetch.mock.calls[0]
+    const formData = callArgs[1].body as FormData
+    
+    // Should include non-null/undefined values
+    expect(formData.get('entry.111')).toBe('100')
+    expect(formData.get('entry.444')).toBe('easy')
+    
+    // Should skip null/undefined values
+    expect(formData.get('entry.222')).toBeNull()
+    expect(formData.get('entry.333')).toBeNull()
+  })
+
+  it('should skip data properties that are not in field mapping', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+
+    const data = { 
+      score: 100, 
+      turns: 10, 
+      unmappedField: 'should be ignored' 
+    }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const fieldMapping = 'score:entry.111;turns:entry.222'
+    
+    postGameStats(data, formsURL, fieldMapping)
+    
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    const callArgs = mockFetch.mock.calls[0]
+    const formData = callArgs[1].body as FormData
+    
+    expect(formData.get('entry.111')).toBe('100')
+    expect(formData.get('entry.222')).toBe('10')
+    
+    // Check that unmapped field is not included
+    const formDataEntries = Array.from(formData.entries())
+    expect(formDataEntries.find(([key]) => key.includes('unmappedField'))).toBeUndefined()
+  })
+
+  it('should work without field mapping', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+
+    const data = { score: 100, turns: 10 }
+    const formsURL = 'https://docs.google.com/forms/test'
+    
+    postGameStats(data, formsURL)
+    
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    expect(mockFetch).toHaveBeenCalledOnce()
+    
+    const callArgs = mockFetch.mock.calls[0]
+    const formData = callArgs[1].body as FormData
+    
+    // No field mapping means no data should be appended
+    const formDataEntries = Array.from(formData.entries())
+    expect(formDataEntries).toHaveLength(0)
+  })
+
+  it('should handle malformed field mapping gracefully', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+
+    const data = { score: 100, turns: 10 }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const malformedMapping = 'score;turns:entry.222;:entry.333;invalidPair'
+    
+    postGameStats(data, formsURL, malformedMapping)
+    
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    expect(mockFetch).toHaveBeenCalledOnce()
+    
+    const callArgs = mockFetch.mock.calls[0]
+    const formData = callArgs[1].body as FormData
+    
+    // Only the valid mapping should work
+    expect(formData.get('entry.222')).toBe('10')
+    
+    // Malformed mappings should be ignored
+    const formDataEntries = Array.from(formData.entries())
+    expect(formDataEntries).toHaveLength(1)
+  })
+
+  it('should convert values to strings', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+
+    const data = { 
+      score: 100, 
+      isWinner: true, 
+      ratio: 3.14,
+      count: 0
+    }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const fieldMapping = 'score:entry.111;isWinner:entry.222;ratio:entry.333;count:entry.444'
+    
+    postGameStats(data, formsURL, fieldMapping)
+    
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    const callArgs = mockFetch.mock.calls[0]
+    const formData = callArgs[1].body as FormData
+    
+    expect(formData.get('entry.111')).toBe('100')
+    expect(formData.get('entry.222')).toBe('true')
+    expect(formData.get('entry.333')).toBe('3.14')
+    expect(formData.get('entry.444')).toBe('0')
+  })
+
+  it('should handle fetch error gracefully', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+    global.fetch = mockFetch
+
+    const data = { score: 100 }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const fieldMapping = 'score:entry.111'
+    
+    postGameStats(data, formsURL, fieldMapping)
+    
+    // Wait for async operation and error handling
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `Failed to post game stats to ${formsURL}: `,
+      expect.any(Error)
+    )
+    
+    consoleSpy.mockRestore()
+  })
+
+  it('should log success message on successful post', async () => {
+    const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+
+    const data = { score: 100 }
+    const formsURL = 'https://docs.google.com/forms/test'
+    const fieldMapping = 'score:entry.111'
+    
+    postGameStats(data, formsURL, fieldMapping)
+    
+    await new Promise(resolve => setTimeout(resolve, 0))
+    
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(consoleSpy).toHaveBeenCalledWith('Game stats posted successfully')
+    
+    consoleSpy.mockRestore()
+  })
+})

--- a/tests/unit/util/stats/postGameStats.spec.ts
+++ b/tests/unit/util/stats/postGameStats.spec.ts
@@ -2,9 +2,13 @@ import postGameStats from '@/util/stats/postGameStats'
 import { expect, vi } from 'vitest'
 
 describe('util/stats/postGameStats', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+  const testFormsURL = 'https://docs.google.com/forms/test'
+
   beforeEach(() => {
     // Mock fetch globally
-    global.fetch = vi.fn()
+    mockFetch = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
     vi.clearAllMocks()
   })
 
@@ -12,12 +16,25 @@ describe('util/stats/postGameStats', () => {
     vi.restoreAllMocks()
   })
 
+  const waitForAsync = () => new Promise(resolve => setTimeout(resolve, 0))
+
+  const getFormDataFromCall = () => {
+    const callArgs = mockFetch.mock.calls[0]
+    return callArgs[1].body as FormData
+  }
+
+  const callPostGameStatsAndWait = async (data: object, formsURL: string, fieldMapping?: string) => {
+    const result = postGameStats(data, formsURL, fieldMapping)
+    await waitForAsync()
+    return result
+  }
+
   it('should skip posting when no formsURL is provided', () => {
     const data = { score: 100, turns: 10 }
     
     postGameStats(data)
     
-    expect(fetch).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 
   it('should skip posting when formsURL is empty string', () => {
@@ -25,80 +42,56 @@ describe('util/stats/postGameStats', () => {
     
     postGameStats(data, '')
     
-    expect(fetch).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 
   it('should post data with correct form data when formsURL is provided', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200
-    })
-    global.fetch = mockFetch
-
     const data = { score: 100, turns: 10, money: 250 }
-    const formsURL = 'https://docs.google.com/forms/test'
     const fieldMapping = 'score:entry.123;turns:entry.456;money:entry.789'
     
-    postGameStats(data, formsURL, fieldMapping)
-    
-    // Wait for async operation
-    await new Promise(resolve => setTimeout(resolve, 0))
+    postGameStats(data, testFormsURL, fieldMapping)
+    await waitForAsync()
     
     expect(mockFetch).toHaveBeenCalledOnce()
     expect(mockFetch).toHaveBeenCalledWith(
-      formsURL,
+      testFormsURL,
       expect.objectContaining({
         method: 'POST',
         mode: 'no-cors'
       })
     )
     
-    // Check that FormData was created with correct mappings
-    const callArgs = mockFetch.mock.calls[0]
-    const formData = callArgs[1].body
+    const formData = getFormDataFromCall()
     expect(formData).toBeInstanceOf(FormData)
   })
 
   it('should map data properties to form fields correctly', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
-    global.fetch = mockFetch
-
     const data = { score: 150, turns: 8, difficulty: 'hard' }
-    const formsURL = 'https://docs.google.com/forms/test'
     const fieldMapping = 'score:entry.111;turns:entry.222;difficulty:entry.333'
     
-    postGameStats(data, formsURL, fieldMapping)
+    postGameStats(data, testFormsURL, fieldMapping)
+    await waitForAsync()
     
-    await new Promise(resolve => setTimeout(resolve, 0))
+    const formData = getFormDataFromCall()
     
-    const callArgs = mockFetch.mock.calls[0]
-    const formData = callArgs[1].body as FormData
-    
-    // Verify form data contains mapped values
     expect(formData.get('entry.111')).toBe('150')
     expect(formData.get('entry.222')).toBe('8')
     expect(formData.get('entry.333')).toBe('hard')
   })
 
   it('should skip undefined and null values in data', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
-    global.fetch = mockFetch
-
     const data = { 
       score: 100, 
       turns: undefined, 
       money: null, 
       difficulty: 'easy' 
     }
-    const formsURL = 'https://docs.google.com/forms/test'
     const fieldMapping = 'score:entry.111;turns:entry.222;money:entry.333;difficulty:entry.444'
     
-    postGameStats(data, formsURL, fieldMapping)
+    postGameStats(data, testFormsURL, fieldMapping)
+    await waitForAsync()
     
-    await new Promise(resolve => setTimeout(resolve, 0))
-    
-    const callArgs = mockFetch.mock.calls[0]
-    const formData = callArgs[1].body as FormData
+    const formData = getFormDataFromCall()
     
     // Should include non-null/undefined values
     expect(formData.get('entry.111')).toBe('100')
@@ -110,23 +103,17 @@ describe('util/stats/postGameStats', () => {
   })
 
   it('should skip data properties that are not in field mapping', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
-    global.fetch = mockFetch
-
     const data = { 
       score: 100, 
       turns: 10, 
       unmappedField: 'should be ignored' 
     }
-    const formsURL = 'https://docs.google.com/forms/test'
     const fieldMapping = 'score:entry.111;turns:entry.222'
     
-    postGameStats(data, formsURL, fieldMapping)
+    postGameStats(data, testFormsURL, fieldMapping)
+    await waitForAsync()
     
-    await new Promise(resolve => setTimeout(resolve, 0))
-    
-    const callArgs = mockFetch.mock.calls[0]
-    const formData = callArgs[1].body as FormData
+    const formData = getFormDataFromCall()
     
     expect(formData.get('entry.111')).toBe('100')
     expect(formData.get('entry.222')).toBe('10')
@@ -137,20 +124,14 @@ describe('util/stats/postGameStats', () => {
   })
 
   it('should work without field mapping', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
-    global.fetch = mockFetch
-
     const data = { score: 100, turns: 10 }
-    const formsURL = 'https://docs.google.com/forms/test'
     
-    postGameStats(data, formsURL)
-    
-    await new Promise(resolve => setTimeout(resolve, 0))
+    postGameStats(data, testFormsURL)
+    await waitForAsync()
     
     expect(mockFetch).toHaveBeenCalledOnce()
     
-    const callArgs = mockFetch.mock.calls[0]
-    const formData = callArgs[1].body as FormData
+    const formData = getFormDataFromCall()
     
     // No field mapping means no data should be appended
     const formDataEntries = Array.from(formData.entries())
@@ -158,21 +139,15 @@ describe('util/stats/postGameStats', () => {
   })
 
   it('should handle malformed field mapping gracefully', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
-    global.fetch = mockFetch
-
     const data = { score: 100, turns: 10 }
-    const formsURL = 'https://docs.google.com/forms/test'
     const malformedMapping = 'score;turns:entry.222;:entry.333;invalidPair'
     
-    postGameStats(data, formsURL, malformedMapping)
-    
-    await new Promise(resolve => setTimeout(resolve, 0))
+    postGameStats(data, testFormsURL, malformedMapping)
+    await waitForAsync()
     
     expect(mockFetch).toHaveBeenCalledOnce()
     
-    const callArgs = mockFetch.mock.calls[0]
-    const formData = callArgs[1].body as FormData
+    const formData = getFormDataFromCall()
     
     // Only the valid mapping should work
     expect(formData.get('entry.222')).toBe('10')
@@ -183,24 +158,18 @@ describe('util/stats/postGameStats', () => {
   })
 
   it('should convert values to strings', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
-    global.fetch = mockFetch
-
     const data = { 
       score: 100, 
       isWinner: true, 
       ratio: 3.14,
       count: 0
     }
-    const formsURL = 'https://docs.google.com/forms/test'
     const fieldMapping = 'score:entry.111;isWinner:entry.222;ratio:entry.333;count:entry.444'
     
-    postGameStats(data, formsURL, fieldMapping)
+    postGameStats(data, testFormsURL, fieldMapping)
+    await waitForAsync()
     
-    await new Promise(resolve => setTimeout(resolve, 0))
-    
-    const callArgs = mockFetch.mock.calls[0]
-    const formData = callArgs[1].body as FormData
+    const formData = getFormDataFromCall()
     
     expect(formData.get('entry.111')).toBe('100')
     expect(formData.get('entry.222')).toBe('true')
@@ -210,21 +179,16 @@ describe('util/stats/postGameStats', () => {
 
   it('should handle fetch error gracefully', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
-    global.fetch = mockFetch
+    mockFetch.mockClear().mockRejectedValue(new Error('Network error'))
 
     const data = { score: 100 }
-    const formsURL = 'https://docs.google.com/forms/test'
     const fieldMapping = 'score:entry.111'
     
-    postGameStats(data, formsURL, fieldMapping)
-    
-    // Wait for async operation and error handling
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await callPostGameStatsAndWait(data, testFormsURL, fieldMapping)
     
     expect(mockFetch).toHaveBeenCalledOnce()
     expect(consoleSpy).toHaveBeenCalledWith(
-      `Failed to post game stats to ${formsURL}: `,
+      `Failed to post game stats to ${testFormsURL}: `,
       expect.any(Error)
     )
     

--- a/tests/unit/util/stats/postGameStats.spec.ts
+++ b/tests/unit/util/stats/postGameStats.spec.ts
@@ -230,23 +230,4 @@ describe('util/stats/postGameStats', () => {
     
     consoleSpy.mockRestore()
   })
-
-  it('should log success message on successful post', async () => {
-    const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true })
-    global.fetch = mockFetch
-
-    const data = { score: 100 }
-    const formsURL = 'https://docs.google.com/forms/test'
-    const fieldMapping = 'score:entry.111'
-    
-    postGameStats(data, formsURL, fieldMapping)
-    
-    await new Promise(resolve => setTimeout(resolve, 0))
-    
-    expect(mockFetch).toHaveBeenCalledOnce()
-    expect(consoleSpy).toHaveBeenCalledWith('Game stats posted successfully')
-    
-    consoleSpy.mockRestore()
-  })
 })


### PR DESCRIPTION
To record final scoring status anonymously in Google Forms.
Any type of data can be recorded, but the POST URL and a field mapping from actual data values to google form entry IDs has to be provided.