### PR TITLE
feat: add Korean (ko) locale

### DIFF
--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,0 +1,23 @@
+{
+  "gameTitle": "brdgm-commons",
+  "notfound": {
+    "title": "찾을 수 없음"
+  },
+  "action": {
+    "abortGame": "게임 중단",
+    "abortGameConfirm": "진행 중인 게임을 중단합니다 - 정말 중단하시겠습니까?",
+    "finishGame": "게임 종료",
+    "finishGameConfirm": "이 게임을 종료합니다 - 정말 종료하시겠습니까?",
+    "cancel": "취소",
+    "back": "뒤로",
+    "close": "닫기",
+    "backToHome": "홈으로 돌아가기"
+  },
+  "footer": {
+    "credits": "크레딧"
+  },
+  "serviceWorkerUpdatedRefresh": {
+    "title": "앱 새로고침",
+    "notice": "앱이 업데이트되었습니다 - 최신 버전을 사용하려면 새로고침하시겠습니까?"
+  }
+}


### PR DESCRIPTION
## Summary

한국어(Korean) 로케일 파일(`ko.json`)을 추가합니다.

- 기존 `en.json` / `de.json`과 동일한 구조
- 공식 한국어판 보드게임 용어 기반 번역
- 자동 구조 검증 통과 (key-structure, placeholder, html, pipe-plurals, no-empty)

## Changes

- `src/locales/ko.json` 추가 (신규 파일)

---
*Generated by brdgm.me localization tool*